### PR TITLE
FIX vars in .env that contain '='

### DIFF
--- a/lib/rack/env.rb
+++ b/lib/rack/env.rb
@@ -30,8 +30,8 @@ module Rack
     def read_env_file(envfile)
       ::File.readlines(envfile).each {|line|
         next if line.chomp == "" || line =~ /^#/
-        key, value = line.chomp.split('=')
-        ENV[key] = value
+        parts = line.chomp.split('=')
+        ENV[parts[0]] = parts[1..-1].join('=')
       } if ::File.exist?(envfile)
     end
   end

--- a/spec/rack/env_spec.rb
+++ b/spec/rack/env_spec.rb
@@ -56,12 +56,17 @@ describe 'Rack::Env' do
       it "should ignore empty line and commented out line" do
         expect{
           request
-        }.to change{ ENV.size }.by(2)
+        }.to change{ ENV.size }.by(3)
       end
 
       it "should load environment variable" do
         request
         expect(ENV['JAPAN']).to eq "Tokyo"
+      end
+
+      it "should load environment variable with '=' inside" do
+        request
+        expect(ENV['SECRET_HASH']).to eq "123$@zzz?a=/b"
       end
     end
 

--- a/spec/tmp/.env
+++ b/spec/tmp/.env
@@ -1,4 +1,5 @@
 JAPAN=Tokyo
 
 BRAZIL=Brasilia
+SECRET_HASH=123$@zzz?a=/b
 # AUSTRARIA=Canberra


### PR DESCRIPTION
Hi, .env files should allow to set variables which contains '='.
When I switched from Foreman to rack-env I noticed a partial string is returned instead.

I attached the fix with the test
